### PR TITLE
Update dxpr_qa_demo.dxpr_builder.settings.yml

### DIFF
--- a/modules/demos/dxpr_qa_demo/config/install/dxpr_qa_demo.dxpr_builder.settings.yml
+++ b/modules/demos/dxpr_qa_demo/config/install/dxpr_qa_demo.dxpr_builder.settings.yml
@@ -4,6 +4,6 @@ cke_fonts: 'Myriad, Calibri/myriad pro",myriad,calibri,arial,tahoma,verdana,sans
 cke_stylesset: 'Lead=p.lead'
 development: false
 format_filters: false
-media_browser: false
+media_browser: 'image_browser'
 record_analytics: true
 notifications: true


### PR DESCRIPTION
fixes missing media browser in QA Demo.